### PR TITLE
Fix Circle CI not able to use SBT properly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,3 +8,11 @@ machine:
       oraclejdk8
   services:
     - docker
+dependencies:
+  pre:
+    - SBT_VERSION=$(sed 's/sbt\.version=\(.*\)/\1/' <project/build.properties)
+    - wget -q https://dl.bintray.com/sbt/debian/sbt-${SBT_VERSION}.deb
+    - sudo dpkg -i sbt-${SBT_VERSION}.deb
+  cache_directories:
+    - "~/.ivy2"
+    - "~/.sbt"

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,3 @@
-general:
-  branches:
-    only:
-      - master
 machine:
   java:
     version:

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,3 @@ machine:
       oraclejdk8
   services:
     - docker
-dependencies:
-  pre:
-    - SBT_VERSION=$(sed 's/sbt\.version=\(.*\)/\1/' <project/build.properties)
-    - wget -q https://dl.bintray.com/sbt/debian/sbt-${SBT_VERSION}.deb
-    - sudo dpkg -i sbt-${SBT_VERSION}.deb
-  cache_directories:
-    - "~/.ivy2"
-    - "~/.sbt"


### PR DESCRIPTION
https://circleci.com/gh/paoloambrosio/drizzle/48

```
$cat /dev/null | sbt test:compile
Detected sbt version 0.13.11
Cannot find sbt launcher 0.13.11
Please download: 
  From  http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.11/sbt-launch.jar
    To  /home/ubuntu/.sbt/.lib/0.13.11/sbt-launch.jar

cat /dev/null | sbt test:compile returned exit code 1

Action failed: sbt test:compile
```